### PR TITLE
Add dependency to kentico libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Follow these steps if you just want to leverage the provider and not care about 
 # Installation
 If you wish to participate on the implementation, follow these steps:
 - Decide which version you want to participate on
-- Copy Lib folder from Kentico instance (of target version) into folder CMS{versionNumber}, e.g. CMS10 for Kentico 10.
 - Open solution file of target version (e.g. k10.sln) in Visual Studio and make sure all references are loaded correctly
 - Copy k{versionNumber}/src/AzureStorageProvider.Tests/App.config.template file as App.config and fill Azure BLOB storage credentials for testing
 

--- a/k10/src/AzureStorageProvider.Tests/AzureStorageProvider.Tests.csproj
+++ b/k10/src/AzureStorageProvider.Tests/AzureStorageProvider.Tests.csproj
@@ -35,40 +35,263 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CMS.Activities, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Activities.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Activities.Loggers, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Activities.Loggers.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.AmazonStorage, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.AmazonStorage.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Automation, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Automation.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.AzureStorage, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.AzureStorage.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.BannerManagement, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.BannerManagement.dll</HintPath>
+    </Reference>
     <Reference Include="CMS.Base, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.Base.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Base.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Blogs, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Blogs.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Chat, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Chat.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Community, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Community.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ContactManagement, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ContactManagement.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ContinuousIntegration, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ContinuousIntegration.dll</HintPath>
     </Reference>
     <Reference Include="CMS.Core, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.CustomTables, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.CustomTables.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DataCom, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DataCom.dll</HintPath>
     </Reference>
     <Reference Include="CMS.DataEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.DataEngine.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DataEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DataProviderSQL, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DataProviderSQL.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DeviceProfiles, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DeviceProfiles.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DocumentEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DocumentEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DocumentWebServices, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DocumentWebServices.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Ecommerce, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Ecommerce.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.EmailEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.EmailEngine.dll</HintPath>
     </Reference>
     <Reference Include="CMS.EventLog, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.EventLog.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.EventLog.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.FileSystemStorage">
-      <HintPath>..\..\..\CMS10\Lib\CMS.FileSystemStorage.dll</HintPath>
+    <Reference Include="CMS.EventManager, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.EventManager.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ExternalAuthentication, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ExternalAuthentication.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.FileSystemStorage, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.FileSystemStorage.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.FormEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.FormEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Forums, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Forums.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Globalization, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Globalization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.HealthMonitoring, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.HealthMonitoring.dll</HintPath>
     </Reference>
     <Reference Include="CMS.Helpers, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.Helpers.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ImportExport, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ImportExport.dll</HintPath>
     </Reference>
     <Reference Include="CMS.IO, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.IO.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.LicenseProvider, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.LicenseProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.LicenseProvider.XmlSerializers, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.LicenseProvider.XmlSerializers.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Localization, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MacroEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.MacroEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MediaLibrary, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.MediaLibrary.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Membership, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Membership.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MembershipProvider, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.MembershipProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MessageBoards, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.MessageBoards.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Messaging, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Messaging.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ModuleLicenses, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ModuleLicenses.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Modules, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Modules.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ModuleUsageTracking, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ModuleUsageTracking.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Mvc, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Newsletters, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Newsletters.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.OnlineForms, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.OnlineForms.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.OnlineMarketing, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.OnlineMarketing.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Personas, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Personas.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Polls, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Polls.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.PortalEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.PortalEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Protection, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Protection.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Relationships, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Relationships.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Reporting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Reporting.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ResponsiveImages, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ResponsiveImages.dll</HintPath>
     </Reference>
     <Reference Include="CMS.Routing.Web, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.Routing.Web.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Routing.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SalesForce, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SalesForce.dll</HintPath>
     </Reference>
     <Reference Include="CMS.Scheduler, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.Scheduler.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Scheduler.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Search.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search.Lucene3, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Search.Lucene3.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search.TextExtractors, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Search.TextExtractors.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SearchProviderSQL, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SearchProviderSQL.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SharePoint, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SharePoint.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SiteProvider, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SiteProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SocialMarketing, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SocialMarketing.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.StrandsRecommender, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.StrandsRecommender.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Synchronization, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Synchronization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Synchronization.WSE3, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Synchronization.WSE3.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SynchronizationEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SynchronizationEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Taxonomy, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Taxonomy.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.TranslationServices, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.TranslationServices.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebAnalytics, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WebAnalytics.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebApi, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WebApi.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebDAV, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WebDAV.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebFarmSync, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WebFarmSync.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebServices, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WebServices.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WIFIntegration, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WIFIntegration.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WinServiceEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WinServiceEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WorkflowEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WorkflowEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="FiftyOne.Foundation, Version=3.2.4.4, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\FiftyOne.Foundation.dll</HintPath>
+    </Reference>
+    <Reference Include="GlobalLink.ProjectDirector.WebServices, Version=4.2.2.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\GlobalLink.ProjectDirector.WebServices.dll</HintPath>
+    </Reference>
+    <Reference Include="ITHit.WebDAV.Server, Version=2.1.1.170, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\ITHit.WebDAV.Server.dll</HintPath>
+    </Reference>
+    <Reference Include="Lucene.Net.v3, Version=3.0.3.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\Lucene.Net.v3.dll</HintPath>
+    </Reference>
+    <Reference Include="Lucene.Net.WordNet.SynExpand, Version=2.0.0.1, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\Lucene.Net.WordNet.SynExpand.dll</HintPath>
+    </Reference>
+    <Reference Include="MaxMindGEOIP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\MaxMindGEOIP.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\WindowsAzure.Storage.9.1.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
@@ -79,6 +302,9 @@
     <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="PDFClown, Version=0.1.2.1, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\PDFClown.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -87,6 +313,12 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="ThoughtWorks.QRCode, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\ThoughtWorks.QRCode.dll</HintPath>
+    </Reference>
+    <Reference Include="Ude, Version=0.1.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\Ude.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AzureHelperTests.cs" />
@@ -123,7 +355,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\NUnit.3.10.1\build\NUnit.props'))" />
     <Error Condition="!Exists('..\..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\Kentico.Libraries.Dependencies.10.0.51\build\net45\Kentico.Libraries.Dependencies.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Kentico.Libraries.Dependencies.10.0.51\build\net45\Kentico.Libraries.Dependencies.targets'))" />
   </Target>
+  <Import Project="..\..\..\packages\Kentico.Libraries.Dependencies.10.0.51\build\net45\Kentico.Libraries.Dependencies.targets" Condition="Exists('..\..\..\packages\Kentico.Libraries.Dependencies.10.0.51\build\net45\Kentico.Libraries.Dependencies.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/k10/src/AzureStorageProvider.Tests/packages.config
+++ b/k10/src/AzureStorageProvider.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Kentico.Libraries" version="10.0.51" targetFramework="net46" allowedVersions="[10.0,11.0)" />
+  <package id="Kentico.Libraries.Dependencies" version="10.0.51" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />

--- a/k10/src/AzureStorageProvider/AzureStorageProvider.csproj
+++ b/k10/src/AzureStorageProvider/AzureStorageProvider.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,46 +33,272 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CMS.Activities, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Activities.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Activities.Loggers, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Activities.Loggers.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.AmazonStorage, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.AmazonStorage.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Automation, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Automation.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.AzureStorage, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.AzureStorage.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.BannerManagement, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.BannerManagement.dll</HintPath>
+    </Reference>
     <Reference Include="CMS.Base, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.Base.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Base.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Blogs, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Blogs.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Chat, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Chat.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Community, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Community.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ContactManagement, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ContactManagement.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ContinuousIntegration, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ContinuousIntegration.dll</HintPath>
     </Reference>
     <Reference Include="CMS.Core, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.CustomTables, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.CustomTables.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DataCom, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DataCom.dll</HintPath>
     </Reference>
     <Reference Include="CMS.DataEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.DataEngine.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DataEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DataProviderSQL, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DataProviderSQL.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DeviceProfiles, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DeviceProfiles.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DocumentEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DocumentEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DocumentWebServices, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.DocumentWebServices.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Ecommerce, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Ecommerce.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.EmailEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.EmailEngine.dll</HintPath>
     </Reference>
     <Reference Include="CMS.EventLog, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.EventLog.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.EventLog.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.FileSystemStorage">
-      <HintPath>..\..\..\CMS10\Lib\CMS.FileSystemStorage.dll</HintPath>
+    <Reference Include="CMS.EventManager, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.EventManager.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ExternalAuthentication, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ExternalAuthentication.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.FileSystemStorage, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.FileSystemStorage.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.FormEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.FormEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Forums, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Forums.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Globalization, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Globalization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.HealthMonitoring, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.HealthMonitoring.dll</HintPath>
     </Reference>
     <Reference Include="CMS.Helpers, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.Helpers.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ImportExport, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ImportExport.dll</HintPath>
     </Reference>
     <Reference Include="CMS.IO, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.IO.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.LicenseProvider, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.LicenseProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.LicenseProvider.XmlSerializers, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.LicenseProvider.XmlSerializers.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Localization, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MacroEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.MacroEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MediaLibrary, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.MediaLibrary.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Membership, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Membership.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MembershipProvider, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.MembershipProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MessageBoards, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.MessageBoards.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Messaging, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Messaging.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ModuleLicenses, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ModuleLicenses.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Modules, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Modules.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ModuleUsageTracking, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ModuleUsageTracking.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Mvc, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Newsletters, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Newsletters.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.OnlineForms, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.OnlineForms.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.OnlineMarketing, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.OnlineMarketing.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Personas, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Personas.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Polls, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Polls.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.PortalEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.PortalEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Protection, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Protection.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Relationships, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Relationships.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Reporting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Reporting.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ResponsiveImages, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.ResponsiveImages.dll</HintPath>
     </Reference>
     <Reference Include="CMS.Routing.Web, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.Routing.Web.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Routing.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SalesForce, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SalesForce.dll</HintPath>
     </Reference>
     <Reference Include="CMS.Scheduler, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\CMS10\Lib\CMS.Scheduler.dll</HintPath>
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Scheduler.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Search.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search.Lucene3, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Search.Lucene3.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search.TextExtractors, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Search.TextExtractors.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SearchProviderSQL, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SearchProviderSQL.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SharePoint, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SharePoint.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SiteProvider, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SiteProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SocialMarketing, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SocialMarketing.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.StrandsRecommender, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.StrandsRecommender.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Synchronization, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Synchronization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Synchronization.WSE3, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Synchronization.WSE3.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SynchronizationEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.SynchronizationEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Taxonomy, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.Taxonomy.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.TranslationServices, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.TranslationServices.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebAnalytics, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WebAnalytics.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebApi, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WebApi.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebDAV, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WebDAV.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebFarmSync, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WebFarmSync.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebServices, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WebServices.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WIFIntegration, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WIFIntegration.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WinServiceEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WinServiceEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WorkflowEngine, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\CMS.WorkflowEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="FiftyOne.Foundation, Version=3.2.4.4, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\FiftyOne.Foundation.dll</HintPath>
+    </Reference>
+    <Reference Include="GlobalLink.ProjectDirector.WebServices, Version=4.2.2.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\GlobalLink.ProjectDirector.WebServices.dll</HintPath>
+    </Reference>
+    <Reference Include="ITHit.WebDAV.Server, Version=2.1.1.170, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\ITHit.WebDAV.Server.dll</HintPath>
+    </Reference>
+    <Reference Include="Lucene.Net.v3, Version=3.0.3.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\Lucene.Net.v3.dll</HintPath>
+    </Reference>
+    <Reference Include="Lucene.Net.WordNet.SynExpand, Version=2.0.0.1, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\Lucene.Net.WordNet.SynExpand.dll</HintPath>
+    </Reference>
+    <Reference Include="MaxMindGEOIP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\MaxMindGEOIP.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\WindowsAzure.Storage.9.1.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="PDFClown, Version=0.1.2.1, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\PDFClown.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -81,6 +309,12 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="ThoughtWorks.QRCode, Version=10.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\ThoughtWorks.QRCode.dll</HintPath>
+    </Reference>
+    <Reference Include="Ude, Version=0.1.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.10.0.51\lib\net45\Ude.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AzureStorageProviderModule.cs" />
@@ -132,6 +366,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\..\packages\Kentico.Libraries.Dependencies.10.0.51\build\net45\Kentico.Libraries.Dependencies.targets" Condition="Exists('..\..\..\packages\Kentico.Libraries.Dependencies.10.0.51\build\net45\Kentico.Libraries.Dependencies.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\Kentico.Libraries.Dependencies.10.0.51\build\net45\Kentico.Libraries.Dependencies.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Kentico.Libraries.Dependencies.10.0.51\build\net45\Kentico.Libraries.Dependencies.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/k10/src/AzureStorageProvider/app.config
+++ b/k10/src/AzureStorageProvider/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.1.0.0" newVersion="9.1.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/k10/src/AzureStorageProvider/packages.config
+++ b/k10/src/AzureStorageProvider/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Kentico.Libraries" version="10.0.51" targetFramework="net46" allowedVersions="[10.0,11.0)"/>
+  <package id="Kentico.Libraries.Dependencies" version="10.0.51" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />

--- a/k11/src/AzureStorageProvider.Tests/AzureStorageProvider.Tests.csproj
+++ b/k11/src/AzureStorageProvider.Tests/AzureStorageProvider.Tests.csproj
@@ -35,47 +35,394 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="AWSSDK.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\AWSSDK.Core.3.1.10.0\lib\net45\AWSSDK.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="AWSSDK.S3, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\AWSSDK.S3.3.1.9.0\lib\net45\AWSSDK.S3.dll</HintPath>
+    </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Castle.Windsor.4.0.0\lib\net45\Castle.Windsor.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.Base">
-      <HintPath>..\..\..\CMS11\Lib\CMS.Base.dll</HintPath>
+    <Reference Include="CMS.Activities, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Activities.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.Core">
-      <HintPath>..\..\..\CMS11\Lib\CMS.Core.dll</HintPath>
+    <Reference Include="CMS.Activities.Loggers, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Activities.Loggers.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.DataEngine">
-      <HintPath>..\..\..\CMS11\Lib\CMS.DataEngine.dll</HintPath>
+    <Reference Include="CMS.AmazonStorage, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.AmazonStorage.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.EventLog">
-      <HintPath>..\..\..\CMS11\Lib\CMS.EventLog.dll</HintPath>
+    <Reference Include="CMS.Automation, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Automation.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.Helpers">
-      <HintPath>..\..\..\CMS11\Lib\CMS.Helpers.dll</HintPath>
+    <Reference Include="CMS.AzureStorage, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.AzureStorage.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.IO">
-      <HintPath>..\..\..\CMS11\Lib\CMS.IO.dll</HintPath>
+    <Reference Include="CMS.BannerManagement, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.BannerManagement.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.Scheduler">
-      <HintPath>..\..\..\CMS11\Lib\CMS.Scheduler.dll</HintPath>
+    <Reference Include="CMS.Base, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Base.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Blogs, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Blogs.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Chat, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Chat.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Community, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Community.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ContactManagement, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.ContactManagement.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ContinuousIntegration, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.ContinuousIntegration.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Core, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.CustomTables, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.CustomTables.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DataEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.DataEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DataProtection, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.DataProtection.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DeviceProfiles, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.DeviceProfiles.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DocumentEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.DocumentEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Ecommerce, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Ecommerce.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.EmailEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.EmailEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.EventLog, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.EventLog.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.EventManager, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.EventManager.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.FormEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.FormEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Forums, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Forums.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Globalization, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Globalization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.HealthMonitoring, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.HealthMonitoring.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Helpers, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ImportExport, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.ImportExport.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.IO, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.LicenseProvider, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.LicenseProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.LicenseProvider.XmlSerializers, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.LicenseProvider.XmlSerializers.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Localization, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MacroEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.MacroEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MediaLibrary, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.MediaLibrary.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Membership, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Membership.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MembershipProvider, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.MembershipProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MessageBoards, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.MessageBoards.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Messaging, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Messaging.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ModuleLicenses, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.ModuleLicenses.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Modules, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Modules.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Newsletters, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Newsletters.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.OnlineForms, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.OnlineForms.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.OnlineMarketing, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.OnlineMarketing.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Personas, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Personas.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Polls, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Polls.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.PortalEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.PortalEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Protection, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Protection.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Relationships, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Relationships.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Reporting, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Reporting.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ResponsiveImages, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.ResponsiveImages.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Routing.Web, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Routing.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SalesForce, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.SalesForce.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Scheduler, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Scheduler.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Search.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search.Azure, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Search.Azure.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search.Lucene3, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Search.Lucene3.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search.TextExtractors, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Search.TextExtractors.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SharePoint, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.SharePoint.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SiteProvider, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.SiteProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SocialMarketing, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.SocialMarketing.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.StrandsRecommender, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.StrandsRecommender.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Synchronization, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Synchronization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Synchronization.WSE3, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Synchronization.WSE3.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SynchronizationEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.SynchronizationEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Taxonomy, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Taxonomy.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.TranslationServices, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.TranslationServices.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebAnalytics, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.WebAnalytics.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebFarmSync, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.WebFarmSync.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WorkflowEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.WorkflowEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetOpenAuth, Version=4.0.0.11165, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\DotNetOpenAuth.dll</HintPath>
+    </Reference>
+    <Reference Include="Facebook, Version=6.0.10.0, Culture=neutral, PublicKeyToken=58cb4f2111d1e6de, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Facebook.6.4.2\lib\net45\Facebook.dll</HintPath>
+    </Reference>
+    <Reference Include="GlobalLink.Connect, Version=4.18.2.0, Culture=neutral, PublicKeyToken=946d606070618fd4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\GlobalLink.Connect.4.18.3.1\lib\net46\GlobalLink.Connect.dll</HintPath>
+    </Reference>
+    <Reference Include="LinqToTwitter.net, Version=4.0.0.0, Culture=neutral, PublicKeyToken=957107be965c25d9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\linqtotwitter.4.0.0\lib\net45\LinqToTwitter.net.dll</HintPath>
+    </Reference>
+    <Reference Include="Lucene.Net.v3, Version=3.0.3.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\Lucene.Net.v3.dll</HintPath>
+    </Reference>
+    <Reference Include="Lucene.Net.WordNet.SynExpand, Version=2.0.0.1, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\Lucene.Net.WordNet.SynExpand.dll</HintPath>
+    </Reference>
+    <Reference Include="MaxMindGEOIP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\MaxMindGEOIP.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Search, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Search.3.0.2\lib\net45\Microsoft.Azure.Search.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Office.Client.Policy, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.Office.Client.Policy.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Office.Client.TranslationServices, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.Office.Client.TranslationServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Office.SharePoint.Tools, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.Office.SharePoint.Tools.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Online.SharePoint.Client.Tenant, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.Online.SharePoint.Client.Tenant.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.ProjectServer.Client, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.ProjectServer.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Rest.ClientRuntime.2.3.4\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Rest.ClientRuntime.Azure.3.3.4\lib\net45\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.DocumentManagement, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.DocumentManagement.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Publishing, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Publishing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Runtime, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Runtime.Windows, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Runtime.Windows.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Search, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Search.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Search.Applications, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Search.Applications.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Taxonomy, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Taxonomy.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.UserProfiles, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.UserProfiles.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.WorkflowServices, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.WorkflowServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Spatial, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Spatial.6.15.0\lib\portable-net45+win+wpa81\Microsoft.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom, Version=13.100.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.Services3, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\Microsoft.Web.Services3.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\WindowsAzure.Storage.9.1.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
+    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="OpenPop, Version=2.0.4.369, Culture=neutral, PublicKeyToken=6bdb97f144b7efc8, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\OpenPop.NET.2.0.4.369\lib\net20\OpenPop.dll</HintPath>
+    </Reference>
+    <Reference Include="PayPal, Version=1.8.0.0, Culture=neutral, PublicKeyToken=5b4afc1ccaef40fb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\PayPal.1.8.0\lib\net451\PayPal.dll</HintPath>
+    </Reference>
+    <Reference Include="PDFClown, Version=0.1.2.1, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\PDFClown.dll</HintPath>
+    </Reference>
+    <Reference Include="PreMailer.Net, Version=1.5.5.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\PreMailer.Net.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data.HashFunction.Core, Version=1.8.2.2, Culture=neutral, PublicKeyToken=80c9288e394c1322, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Data.HashFunction.Core.1.8.2.2\lib\net45\System.Data.HashFunction.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.HashFunction.CRC, Version=1.8.2.2, Culture=neutral, PublicKeyToken=80c9288e394c1322, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Data.HashFunction.CRC.1.8.2.2\lib\net45\System.Data.HashFunction.CRC.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.HashFunction.Interfaces, Version=1.0.0.2, Culture=neutral, PublicKeyToken=80c9288e394c1322, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Data.HashFunction.Interfaces.1.0.0.2\lib\net45\System.Data.HashFunction.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.IO.FileSystem.Primitives.4.0.1\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.IO.Packaging.4.0.0\lib\net46\System.IO.Packaging.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Ude, Version=0.1.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\Ude.dll</HintPath>
+    </Reference>
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AzureHelperTests.cs" />
@@ -99,7 +446,9 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Analyzer Include="..\..\..\packages\AWSSDK.S3.3.1.9.0\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AzureStorageProvider\AzureStorageProvider.csproj">
       <Project>{b40d30b8-51b1-4568-b3ad-13ed85f7ff69}</Project>

--- a/k11/src/AzureStorageProvider.Tests/packages.config
+++ b/k11/src/AzureStorageProvider.Tests/packages.config
@@ -1,16 +1,44 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AngleSharp" version="0.9.9" targetFramework="net46" />
+  <package id="AWSSDK.Core" version="3.1.10.0" targetFramework="net46" />
+  <package id="AWSSDK.S3" version="3.1.9.0" targetFramework="net46" />
   <package id="Castle.Core" version="4.0.0" targetFramework="net46" />
   <package id="Castle.Windsor" version="4.0.0" targetFramework="net46" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net46" />
+  <package id="Facebook" version="6.4.2" targetFramework="net46" />
+  <package id="GlobalLink.Connect" version="4.18.3.1" targetFramework="net46" />
+  <package id="Kentico.Libraries" version="11.0.38" targetFramework="net46" allowedVersions="[11.0,12.0)" />
+  <package id="linqtotwitter" version="4.0.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Search" version="3.0.2" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.4" targetFramework="net46" />
+  <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.4" targetFramework="net46" />
+  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.6621.1200" targetFramework="net46" />
+  <package id="Microsoft.Spatial" version="6.15.0" targetFramework="net46" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
+  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net46" />
   <package id="NUnit" version="3.10.1" targetFramework="net46" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net46" />
+  <package id="OpenPop.NET" version="2.0.4.369" targetFramework="net46" />
+  <package id="PayPal" version="1.8.0" targetFramework="net46" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net46" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net452" />
+  <package id="System.Data.HashFunction.Core" version="1.8.2.2" targetFramework="net46" />
+  <package id="System.Data.HashFunction.CRC" version="1.8.2.2" targetFramework="net46" />
+  <package id="System.Data.HashFunction.Interfaces" version="1.0.0.2" targetFramework="net46" />
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net46" />
+  <package id="System.IO.Packaging" version="4.0.0" targetFramework="net46" />
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net452" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net452" />
   <package id="System.Spatial" version="5.8.2" targetFramework="net452" />

--- a/k11/src/AzureStorageProvider/AzureStorageProvider.csproj
+++ b/k11/src/AzureStorageProvider/AzureStorageProvider.csproj
@@ -33,41 +33,380 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="AWSSDK.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\AWSSDK.Core.3.1.10.0\lib\net45\AWSSDK.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="AWSSDK.S3, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\AWSSDK.S3.3.1.9.0\lib\net45\AWSSDK.S3.dll</HintPath>
+    </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Castle.Windsor.4.0.0\lib\net45\Castle.Windsor.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.Base">
-      <HintPath>..\..\..\CMS11\Lib\CMS.Base.dll</HintPath>
+    <Reference Include="CMS.Activities, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Activities.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.Core">
-      <HintPath>..\..\..\CMS11\Lib\CMS.Core.dll</HintPath>
+    <Reference Include="CMS.Activities.Loggers, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Activities.Loggers.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.DataEngine">
-      <HintPath>..\..\..\CMS11\Lib\CMS.DataEngine.dll</HintPath>
+    <Reference Include="CMS.AmazonStorage, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.AmazonStorage.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.EventLog">
-      <HintPath>..\..\..\CMS11\Lib\CMS.EventLog.dll</HintPath>
+    <Reference Include="CMS.Automation, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Automation.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.Helpers">
-      <HintPath>..\..\..\CMS11\Lib\CMS.Helpers.dll</HintPath>
+    <Reference Include="CMS.AzureStorage, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.AzureStorage.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.IO">
-      <HintPath>..\..\..\CMS11\Lib\CMS.IO.dll</HintPath>
+    <Reference Include="CMS.BannerManagement, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.BannerManagement.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.Routing.Web">
-      <HintPath>..\..\..\CMS11\Lib\CMS.Routing.Web.dll</HintPath>
+    <Reference Include="CMS.Base, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Base.dll</HintPath>
     </Reference>
-    <Reference Include="CMS.Scheduler">
-      <HintPath>..\..\..\CMS11\Lib\CMS.Scheduler.dll</HintPath>
+    <Reference Include="CMS.Blogs, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Blogs.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Chat, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Chat.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Community, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Community.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ContactManagement, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.ContactManagement.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ContinuousIntegration, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.ContinuousIntegration.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Core, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.CustomTables, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.CustomTables.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DataEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.DataEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DataProtection, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.DataProtection.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DeviceProfiles, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.DeviceProfiles.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.DocumentEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.DocumentEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Ecommerce, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Ecommerce.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.EmailEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.EmailEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.EventLog, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.EventLog.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.EventManager, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.EventManager.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.FormEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.FormEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Forums, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Forums.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Globalization, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Globalization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.HealthMonitoring, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.HealthMonitoring.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Helpers, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ImportExport, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.ImportExport.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.IO, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.LicenseProvider, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.LicenseProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.LicenseProvider.XmlSerializers, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.LicenseProvider.XmlSerializers.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Localization, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MacroEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.MacroEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MediaLibrary, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.MediaLibrary.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Membership, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Membership.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MembershipProvider, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.MembershipProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.MessageBoards, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.MessageBoards.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Messaging, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Messaging.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ModuleLicenses, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.ModuleLicenses.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Modules, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Modules.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Newsletters, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Newsletters.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.OnlineForms, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.OnlineForms.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.OnlineMarketing, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.OnlineMarketing.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Personas, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Personas.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Polls, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Polls.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.PortalEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.PortalEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Protection, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Protection.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Relationships, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Relationships.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Reporting, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Reporting.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.ResponsiveImages, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.ResponsiveImages.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Routing.Web, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Routing.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SalesForce, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.SalesForce.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Scheduler, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Scheduler.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Search.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search.Azure, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Search.Azure.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search.Lucene3, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Search.Lucene3.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Search.TextExtractors, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Search.TextExtractors.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SharePoint, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.SharePoint.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SiteProvider, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.SiteProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SocialMarketing, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.SocialMarketing.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.StrandsRecommender, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.StrandsRecommender.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Synchronization, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Synchronization.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Synchronization.WSE3, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Synchronization.WSE3.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.SynchronizationEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.SynchronizationEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.Taxonomy, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.Taxonomy.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.TranslationServices, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.TranslationServices.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebAnalytics, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.WebAnalytics.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WebFarmSync, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.WebFarmSync.dll</HintPath>
+    </Reference>
+    <Reference Include="CMS.WorkflowEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\CMS.WorkflowEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\DocumentFormat.OpenXml.2.7.2\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetOpenAuth, Version=4.0.0.11165, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\DotNetOpenAuth.dll</HintPath>
+    </Reference>
+    <Reference Include="Facebook, Version=6.0.10.0, Culture=neutral, PublicKeyToken=58cb4f2111d1e6de, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Facebook.6.4.2\lib\net45\Facebook.dll</HintPath>
+    </Reference>
+    <Reference Include="GlobalLink.Connect, Version=4.18.2.0, Culture=neutral, PublicKeyToken=946d606070618fd4, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\GlobalLink.Connect.4.18.3.1\lib\net46\GlobalLink.Connect.dll</HintPath>
+    </Reference>
+    <Reference Include="LinqToTwitter.net, Version=4.0.0.0, Culture=neutral, PublicKeyToken=957107be965c25d9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\linqtotwitter.4.0.0\lib\net45\LinqToTwitter.net.dll</HintPath>
+    </Reference>
+    <Reference Include="Lucene.Net.v3, Version=3.0.3.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\Lucene.Net.v3.dll</HintPath>
+    </Reference>
+    <Reference Include="Lucene.Net.WordNet.SynExpand, Version=2.0.0.1, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\Lucene.Net.WordNet.SynExpand.dll</HintPath>
+    </Reference>
+    <Reference Include="MaxMindGEOIP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\MaxMindGEOIP.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Search, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Azure.Search.3.0.2\lib\net45\Microsoft.Azure.Search.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Office.Client.Policy, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.Office.Client.Policy.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Office.Client.TranslationServices, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.Office.Client.TranslationServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Office.SharePoint.Tools, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.Office.SharePoint.Tools.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Online.SharePoint.Client.Tenant, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.Online.SharePoint.Client.Tenant.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.ProjectServer.Client, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.ProjectServer.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Rest.ClientRuntime.2.3.4\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Rest.ClientRuntime.Azure.3.3.4\lib\net45\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.DocumentManagement, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.DocumentManagement.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Publishing, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Publishing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Runtime, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Runtime.Windows, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Runtime.Windows.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Search, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Search.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Search.Applications, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Search.Applications.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.Taxonomy, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.Taxonomy.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.UserProfiles, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.UserProfiles.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SharePoint.Client.WorkflowServices, Version=16.1.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.SharePointOnline.CSOM.16.1.6621.1200\lib\net45\Microsoft.SharePoint.Client.WorkflowServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Spatial, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Spatial.6.15.0\lib\portable-net45+win+wpa81\Microsoft.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom, Version=13.100.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.Services3, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\Microsoft.Web.Services3.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\WindowsAzure.Storage.9.1.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
+    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenPop, Version=2.0.4.369, Culture=neutral, PublicKeyToken=6bdb97f144b7efc8, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\OpenPop.NET.2.0.4.369\lib\net20\OpenPop.dll</HintPath>
+    </Reference>
+    <Reference Include="PayPal, Version=1.8.0.0, Culture=neutral, PublicKeyToken=5b4afc1ccaef40fb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\PayPal.1.8.0\lib\net451\PayPal.dll</HintPath>
+    </Reference>
+    <Reference Include="PDFClown, Version=0.1.2.1, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\PDFClown.dll</HintPath>
+    </Reference>
+    <Reference Include="PreMailer.Net, Version=1.5.5.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\PreMailer.Net.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data.HashFunction.Core, Version=1.8.2.2, Culture=neutral, PublicKeyToken=80c9288e394c1322, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Data.HashFunction.Core.1.8.2.2\lib\net45\System.Data.HashFunction.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.HashFunction.CRC, Version=1.8.2.2, Culture=neutral, PublicKeyToken=80c9288e394c1322, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Data.HashFunction.CRC.1.8.2.2\lib\net45\System.Data.HashFunction.CRC.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.HashFunction.Interfaces, Version=1.0.0.2, Culture=neutral, PublicKeyToken=80c9288e394c1322, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Data.HashFunction.Interfaces.1.0.0.2\lib\net45\System.Data.HashFunction.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.IO.FileSystem.Primitives.4.0.1\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.IO.Packaging.4.0.0\lib\net46\System.IO.Packaging.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -75,6 +414,10 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Ude, Version=0.1.0.0, Culture=neutral, PublicKeyToken=834b12a258f213f9, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Kentico.Libraries.11.0.38\lib\net46\Ude.dll</HintPath>
+    </Reference>
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AzureStorageProviderModule.cs" />
@@ -122,7 +465,11 @@
     <Compile Include="Tasks\CacheClearingTask.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\..\packages\AWSSDK.S3.3.1.9.0\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/k11/src/AzureStorageProvider/app.config
+++ b/k11/src/AzureStorageProvider/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.1.0.0" newVersion="9.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/k11/src/AzureStorageProvider/packages.config
+++ b/k11/src/AzureStorageProvider/packages.config
@@ -1,15 +1,43 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AngleSharp" version="0.9.9" targetFramework="net46" />
+  <package id="AWSSDK.Core" version="3.1.10.0" targetFramework="net46" />
+  <package id="AWSSDK.S3" version="3.1.9.0" targetFramework="net46" />
   <package id="Castle.Core" version="4.0.0" targetFramework="net46" />
   <package id="Castle.Windsor" version="4.0.0" targetFramework="net46" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net46" />
+  <package id="Facebook" version="6.4.2" targetFramework="net46" />
+  <package id="GlobalLink.Connect" version="4.18.3.1" targetFramework="net46" />
+  <package id="Kentico.Libraries" version="11.0.38" targetFramework="net46"  allowedVersions="[11.0,12.0)" />
+  <package id="linqtotwitter" version="4.0.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Search" version="3.0.2" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net452" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.4" targetFramework="net46" />
+  <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.4" targetFramework="net46" />
+  <package id="Microsoft.SharePointOnline.CSOM" version="16.1.6621.1200" targetFramework="net46" />
+  <package id="Microsoft.Spatial" version="6.15.0" targetFramework="net46" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
+  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net46" />
   <package id="NUnit" version="3.10.1" targetFramework="net46" />
+  <package id="OpenPop.NET" version="2.0.4.369" targetFramework="net46" />
+  <package id="PayPal" version="1.8.0" targetFramework="net46" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net46" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net452" />
+  <package id="System.Data.HashFunction.Core" version="1.8.2.2" targetFramework="net46" />
+  <package id="System.Data.HashFunction.CRC" version="1.8.2.2" targetFramework="net46" />
+  <package id="System.Data.HashFunction.Interfaces" version="1.0.0.2" targetFramework="net46" />
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net46" />
+  <package id="System.IO.Packaging" version="4.0.0" targetFramework="net46" />
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net452" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net452" />
   <package id="System.Spatial" version="5.8.2" targetFramework="net452" />


### PR DESCRIPTION
Hi,
this PR fixes #5 issue. 

I've sort of figured out, that Kentico.Library major version must match with project k{version}, otherwise they are not able to compile. For that reason I've added `allowedVersions` attribute in package configs.

I was not able to run all the tests. I think, the reason might be not having the proper BLOB Azure credentials, but I'm new to Azure, so the mistake might be elsewhere.

